### PR TITLE
New prepend_view_path for Cell::Base (Rails 2.3 branch)

### DIFF
--- a/lib/cells/cell/base.rb
+++ b/lib/cells/cell/base.rb
@@ -162,6 +162,12 @@ module Cells
           self.view_paths << path unless self.view_paths.include?(path)
         end
 
+        # Prepend a path in the list of Cells view paths
+        def prepend_view_path(path)
+          path = File.join(::Rails.root, path) if defined?(::Rails) and ::Rails.respond_to?(:root)
+          self.view_paths.unshift(path) unless self.view_paths.include?(path)
+        end
+
         # Creates a cell instance of the class <tt>name</tt>Cell, passing through
         # <tt>opts</tt>.
         def create_cell_for(controller, name, opts={})

--- a/test/cells_test.rb
+++ b/test/cells_test.rb
@@ -132,8 +132,12 @@ class CellsTest < ActionController::TestCase
     Cell::Base.add_view_path 'now'
     assert_kind_of ActionView::PathSet, Cell::Base.view_paths
   end
-  
-  
+
+  def test_prepend_view_path
+    Cell::Base.prepend_view_path 'now'
+    assert_kind_of ActionView::PathSet, Cell::Base.view_paths
+  end
+
   def test_controller_render_methods
     get :call_render_cell_with_strings  # render_cell("test", "state")
     assert_response :success


### PR DESCRIPTION
Here is a little patch to add support for a Rails' like prepend_view_path.
