### PR TITLE
Dsl

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -43,7 +43,11 @@ That looks very familiar.
 Now, render your cart. Why not put it in <tt>layouts/application.html.erb</tt> for now? 
 
   <div id="header">
-    <%= render_cell :shopping_cart, :display, :user => @current_user %>
+    <%= cell[:shopping_cart].display :user => @current_user %>
+
+You can also invoke it without the dsl:
+
+	<%= render_cell :shopping_cart, :display, :user => @current_user %>
 
 Feels like rendering a controller action. As additional encapsulation we pass the current +user+ from outside. Call it knowledge hiding.
 
@@ -112,7 +116,7 @@ Let +render_cell+ take care of creating the right cell. Just configure your supe
   
 A call to
 
-  render_cell(:login, :box)
+  cell[:login].box
 
 will render the configured +UnauthorizedUserCell+ instead of the original +LoginCell+ if the login test fails.
 

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ task :default => :test
 desc 'Test the cells plugin.'
 Rake::TestTask.new(:test) do |test|
   test.libs << 'test'
-  test.test_files = FileList['test/*_test.rb', 'test/rails/*_test.rb'] - ['test/rails/capture_test.rb']
+  test.test_files = FileList['test/*_test.rb', 'test/rails/*_test.rb', 'test/cell/*_test.rb'] - ['test/rails/capture_test.rb']
   test.verbose = true
 end
 

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -1,5 +1,7 @@
 module Cell
   autoload :Caching,      'cell/caching'
+  autoload :Lookup,       'cell/lookup'
+  autoload :Dsl,          'cell/dsl'
   
   extend ActiveSupport::Concern
     

--- a/lib/cell/dsl.rb
+++ b/lib/cell/dsl.rb
@@ -1,0 +1,15 @@
+module Cell
+  class Dsl
+    
+    def initialize(controller, name)
+      @controller = controller
+      @name = name
+    end
+    
+    # Returns the cell content by delegating the invocation to render_cell_for
+    def method_missing(sym, opts = {}, &block)
+      ::Cell::Base.render_cell_for(@controller, @name, sym, opts, &block)
+    end
+    
+  end
+end

--- a/lib/cell/lookup.rb
+++ b/lib/cell/lookup.rb
@@ -1,0 +1,17 @@
+module Cell
+  class Lookup
+    
+    def initialize(controller)
+      @controller = controller
+    end
+    
+    # Lookups up a cell by its name
+    # Example:
+    #
+    #   Cell::Lookup.new(self)["name"]
+    def [](name)
+      ::Cell::Dsl.new(@controller, name)
+    end
+    
+  end
+end

--- a/lib/cells/rails.rb
+++ b/lib/cells/rails.rb
@@ -21,6 +21,23 @@ module Cells
         ::Cell::Base.render_cell_for(self, name, state, opts, &block)
       end
 
+      # DSL for rendering a cell, implemented as a delegator to render_cell.
+      # 
+      # Example:
+      #
+      #   @box = cell[:posts].latest(:user => current_user)
+      #
+      # If you need the cell instance before it renders, you can pass a block receiving the cell.
+      #
+      # Example:
+      #
+      #   @box = cell[:comments].top5 do |cell|
+      #     cell.markdown! if config.parse_comments?
+      #   end
+      def cell
+        ::Cell::Lookup.with(self)
+      end
+
       # Expires the cached cell state view, similar to ActionController::expire_fragment.
       # Usually, this method is used in Sweepers.
       # Beside the obvious first two args <tt>cell_name</tt> and <tt>state</tt> you can pass

--- a/test/cell/dsl_test.rb
+++ b/test/cell/dsl_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class DslTest < ActiveSupport::TestCase
+  include Cell::TestCase::TestMethods
+  
+  context "A dsl" do
+    should "delegate missing methods to render cell" do
+      assert_equal "Doo", Cell::Dsl.new(@controller, :bassist).play
+    end
+  end
+  
+end

--- a/test/cell/lookup_test.rb
+++ b/test/cell/lookup_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class DslTest < ActiveSupport::TestCase
+  include Cell::TestCase::TestMethods
+  
+  context "A lookup process" do
+    should "delegate its finder to a render cell" do
+      assert_equal "Doo", Cell::Lookup.new(@controller)[:bassist].play
+    end
+  end
+  
+end


### PR DESCRIPTION
A simple dsl builder on top of the cell rendering process. It allows one to:

   cell[:user].box

Instead of

   render_cell :user, :box
