### PR TITLE
Fix route helper output for apps mounted at places other than /

### DIFF
--- a/lib/cell/rails3_1_strategy.rb
+++ b/lib/cell/rails3_1_strategy.rb
@@ -3,8 +3,7 @@ module Cell
   module VersionStrategy
     extend ActiveSupport::Concern
     
-    include AbstractController::UrlFor  # must be included before _routes is set in Railstie.
-    
+    include ActionController::UrlFor  # must be included before _routes is set in Railtie.
     
     module ClassMethods
       def view_context_class


### PR DESCRIPTION
The inclusion of ActionController::UrlFor rather than AbstractController::UrlFor means that application specific url_options are mixed in correctly to Cells and that route helpers now correctly render routes within cell views according to the same rules applied within standard views.

While this fix was generated to support applications mounted at paths other than directly under '/', this should also fix other route rendering issues related to url_options.
