### PR TITLE
remove rails 3.1 specific initializer ordering code

### DIFF
--- a/lib/cells/railtie.rb
+++ b/lib/cells/railtie.rb
@@ -3,7 +3,6 @@ require "rails/railtie"
 module Cells
   class Railtie < Rails::Railtie
     options = {}
-    options[:after] = :set_routes_reloader if Cells.rails3_1?
     
     initializer "cells.attach_router", options  do |app|
       Cell::Rails.class_eval do


### PR DESCRIPTION
With this change, cells no longer breaks loading of engines/plugins while route helpers still remain available within cell views (which was the driving factor behind including this initialization logic in the first place :))
