### PR TITLE
Fix route helper output for apps mounted at places other than / [attempt 2]

### DIFF
--- a/lib/cell/rails.rb
+++ b/lib/cell/rails.rb
@@ -33,14 +33,14 @@ module Cell
 
 
     module Metal
-      delegate :session, :params, :request, :config, :env, :to => :parent_controller
+      delegate :session, :params, :request, :config, :env, :url_options, :to => :parent_controller
     end 
     
     
+    include VersionStrategy
     include Metal
     include Rendering
     include Caching
-    include VersionStrategy
     
     
     attr_reader :parent_controller


### PR DESCRIPTION
Ok, after having read the concerns in #45, I agree that #52 was not the correct solution.

So, how about this patch which follows the pattern of delegation of request-centric objects to the parent controller, adding url_options to the list of delegated methods?
