### PR TITLE
Rails 2.3 branch: autoload_paths fix, backwards compatible

### DIFF
--- a/rails/init.rb
+++ b/rails/init.rb
@@ -5,7 +5,11 @@ require 'cells'
 #
 #   * +app/cells+
 #
-ActiveSupport::Dependencies.load_paths << Rails.root.join(*%w[app cells])
+if ::ActiveSupport::Dependencies.respond_to?(:autoload_paths)
+  ActiveSupport::Dependencies.autoload_paths << Rails.root.join(*%w[app cells])
+else
+  ActiveSupport::Dependencies.load_paths << Rails.root.join(*%w[app cells])
+end
 
 # Rails initialization hook.
 if defined?(Rails)
@@ -24,7 +28,11 @@ if defined?(Rails)
         
         # if a path is in +load_once_path+ it won't be reloaded between requests.
         unless config.reload_plugins?
-          ::ActiveSupport::Dependencies.load_once_paths << engine_cells_dir
+          if ::ActiveSupport::Dependencies.respond_to?(:autoload_once_paths)
+            ::ActiveSupport::Dependencies.autoload_once_paths << engine_cells_dir
+          else
+            ::ActiveSupport::Dependencies.load_once_paths << engine_cells_dir
+          end
         end
       end
     end


### PR DESCRIPTION
Will work with all rails 2.3 versions, not just 2.3.11.
