### PR TITLE
Removed explicit require 'cells/test_case' line, as it causes problems

### DIFF
--- a/lib/cells.rb
+++ b/lib/cells.rb
@@ -83,8 +83,6 @@ end
 require 'cell/rails'
 require 'cells/railtie'
 require 'cells/rails'
-require 'cell/test_case' if Rails.env == "test"
-
 require 'cells/rails_compat'  # fixes a bug in Rails <3.0.4. # TODO: remove me as soon as we support 3.1, only.
 
 Cell::Base = Cell::Rails


### PR DESCRIPTION
The line removed in this commit was causing my view specs to not have access to the default set of Rails helpers. My current hypothesis is that prematurely including `cells/test_case` is not the best idea, and causes some weird loading issues.

This `require` statement should be moved into `test_helper.rb` or `spec_helper.rb`, after the Rails environment has been loaded.

In the case of rspec-cells, Rails will automatically load Cells::TestCase when it encounters the first reference to it, so we don't need this line. Most likely this is the case for Test::Unit as well.

Unfortunately, I can only reproduce this bug in my app, and not in a fresh one. In any case, this seems like a line that doesn't need to be here.
