### PR TITLE
Alllow caching conditionally.

### DIFF
--- a/test/rails/caching_test.rb
+++ b/test/rails/caching_test.rb
@@ -283,5 +283,28 @@ class CachingFunctionalTest < ActiveSupport::TestCase
       assert_equal "1", render_cell(:director, :count, 3)
       assert_equal "2", render_cell(:director, :count, 4)
     end
+    
+    should "be able to use caching conditionally" do
+      @class.cache :count, :if => proc { |cell, int| (int % 2) != 0 }
+      
+      assert_equal "1", render_cell(:director, :count, 1)
+      assert_equal "2", render_cell(:director, :count, 2)
+      assert_equal "1", render_cell(:director, :count, 3)
+      assert_equal "4", render_cell(:director, :count, 4)
+    end
+    
+    should "cache conditionally with an instance method" do
+      @class.cache :count, :if => :odd?
+      @class.class_eval do
+        def odd?(int)
+          (int % 2) != 0
+        end
+      end
+      
+      assert_equal "1", render_cell(:director, :count, 1)
+      assert_equal "2", render_cell(:director, :count, 2)
+      assert_equal "1", render_cell(:director, :count, 3)
+      assert_equal "4", render_cell(:director, :count, 4)
+    end
   end
 end


### PR DESCRIPTION
Hey Nick, just saw you commented on this. I'd been meaning to make a pull request, so here it is:

The cache class method can be passed an :if option which specifies a proc or method name. If the proc returns nil or false, the caching will be skipped.

My current main use case for this is for rendering lists of songs some of which are fairly static - e.g. top 20, and some of which are not e.g. search result listings. Another case is caching the hundred most popular items, but not the next 9,900 items.
