### PR TITLE
Add gem's lib/ directory to config.autoload_paths

### DIFF
--- a/lib/cells/railtie.rb
+++ b/lib/cells/railtie.rb
@@ -7,11 +7,15 @@ module Cells
         include app.routes.url_helpers
       end
     end
-    
+
     initializer "cells.setup_view_paths" do |app|
       Cell::Base.setup_view_paths!
     end
-    
+
+    initializer "cells.add_autoload_paths", :before => :set_autoload_paths do |app|
+      app.config.autoload_paths << File.expand_path("../../lib", File.dirname(__FILE__))
+    end
+
     rake_tasks do
       load "cells/cells.rake"
     end


### PR DESCRIPTION
- One of the benefits is that user does not need to explicitly require Cell::TestCase in his test_helper.rb

It's one of possible ways to fix #68, not necessarily the best one. While I can't see anything wrong with this approach, at least as long as all classes are namespaced, no other gem used by my application seems to do this (and I am using lots of them). Pull it in if you think it's a good idea.
