### PR TITLE
Test examples to illustrate #cycle problem [issue #75]

### DIFF
--- a/test/app/cells/bassist/plink_plonk.html.haml
+++ b/test/app/cells/bassist/plink_plonk.html.haml
@@ -1,0 +1,1 @@
+= (1..3).map { cycle("plink", "plonk") }.join(" ")

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -9,7 +9,7 @@ end
 
 class DrummerCell < Cell::Base
   helper StringHelper
-          
+
   def assist
     render :inline => "<%= pick %>"
   end
@@ -18,7 +18,7 @@ end
 
 class HelperTest < ActionController::TestCase
   include Cell::TestCase::TestMethods
-  
+
   context "a cell view" do
     should "have access to all helpers" do
       BassistCell.class_eval do
@@ -26,37 +26,58 @@ class HelperTest < ActionController::TestCase
           render :inline => "<%= submit_tag %>"
         end
       end
-      
+
       assert_equal "<input name=\"commit\" type=\"submit\" value=\"Save changes\" />", render_cell(:bassist, :assist)
     end
-    
+
     should "have access to methods declared with helper_method" do
       BassistCell.class_eval do
         def help; "Great!"; end
         helper_method :help
-          
+
         def assist
           render :inline => "<%= help %>"
         end
       end
-      
+
       assert_equal "Great!", render_cell(:bassist, :assist)
     end
-    
+
     should "have access to methods provided by helper" do
       assert_equal "plong", render_cell(:drummer, :assist)
     end
-    
+
     should "mix in required helpers, only" do
       assert_equal "false true", render_cell(:"club_security/medic", :help)
       assert_equal "true false", render_cell(:"club_security/guard", :help)
     end
-    
+
     should "include helpers only once" do
       assert_equal "false true", render_cell(:"club_security/medic", :help)
       assert_equal "true false", render_cell(:"club_security/guard", :help)
       assert_equal "false true", render_cell(:"club_security/medic", :help)
       assert_equal "true false", render_cell(:"club_security/guard", :help)
+    end
+
+    should "be able to use the #cycle helper" do
+      BassistCell.class_eval do
+        def assist
+          render :view => 'plink_plonk'
+        end
+      end
+
+      assert_equal "plink plonk plink\n", render_cell(:bassist, :assist)
+    end
+
+    should "maintain the #cycle state between cell renders" do
+      BassistCell.class_eval do
+        def assist
+          render :view => 'plink_plonk'
+        end
+      end
+
+      assert_equal "plink plonk plink\n", render_cell(:bassist, :assist)
+      assert_equal "plonk plink plonk\n", render_cell(:bassist, :assist)
     end
   end
 end


### PR DESCRIPTION
Hi,

I'm having the same issue reported in #75 - I saw there that you requested some test examples, so I've provided them here.

The first new test passes, so the helper works within a single render_cell call. The second fails, implying that the cycle state is lost between sequential render_cell calls.

Let me know if there's any more information that would be useful, I'll be glad to provide it.

Cheers,
Simon

(edit: I should say, I'm trying to track down the cause of this myself - I'm completely new to cells though, so if anyone's got any pointers as to promising places to start looking, it'd be greatly appreciated... :-))
