### PR TITLE
Allow #render_cell in a state

### DIFF
--- a/lib/cell/rails.rb
+++ b/lib/cell/rails.rb
@@ -131,6 +131,24 @@ module Cell
       render_view_for(self.action_name, *args)
     end
 
+    # Renders the cell state and returns the content. You may pass options here, too. They will be
+    # around in @opts.
+    #
+    # Example:
+    #
+    #   @box = render_cell(:posts, :latest, :user => current_user)
+    #
+    # If you need the cell instance before it renders, you can pass a block receiving the cell.
+    #
+    # Example:
+    #
+    #   @box = render_cell(:comments, :top5) do |cell|
+    #     cell.markdown! if config.parse_comments?
+    #   end
+    def render_cell(name, state, *args, &block)
+      ::Cell::Base.render_cell_for(self, name, state, *args, &block)
+    end
+
   private
     # Renders the view belonging to the given state. Will raise ActionView::MissingTemplate
     # if it can't find a view.

--- a/test/rails/render_test.rb
+++ b/test/rails/render_test.rb
@@ -176,6 +176,15 @@ class RailsRenderTest < ActiveSupport::TestCase
     end
   end
   
+  context "Invoking render_cell" do
+    should "render the target cell and state" do
+      TrumpeterCell.class_eval do
+        def chunky_bacon; render_cell :bassist, :shout, :words => 'chunky bacon'; end
+      end
+      assert_equal "*shouts* chunky bacon\n", render_cell(:trumpeter, :chunky_bacon)
+    end
+  end
+
   context "A cell view" do
     # rails view api
     should "allow calls to params/response/..." do


### PR DESCRIPTION
Hey Nick. This pull request makes it possible to call `render_cell` from within a state.
