### PR TITLE
Rails 2.3

### DIFF
--- a/lib/cells.rb
+++ b/lib/cells.rb
@@ -66,4 +66,4 @@ end
 Cell::Base.view_paths = Cells::DEFAULT_VIEW_PATHS if Cell::Base.view_paths.blank?
 
 require 'cells/rails'
-require 'cells/cell/test_case' if ENV['RAILS_ENV'] = 'test'
+require 'cells/cell/test_case' if ENV['RAILS_ENV'] == 'test'


### PR DESCRIPTION
Fixed typo so ENV['RAILS_ENV'] is compared to 'test' rather than set to 'test'.

I didn't bump the version or anything else, just changed an errant "=" to "==".
