### PR TITLE
treat rails ~> 3.1 the same

### DIFF
--- a/lib/cell/base.rb
+++ b/lib/cell/base.rb
@@ -3,7 +3,7 @@ require 'cell/builder'
 require 'cell/caching'
 require 'cell/rendering'
 require 'cell/rails3_0_strategy' if Cells.rails3_0?
-require 'cell/rails3_1_strategy' if Cells.rails3_1?
+require 'cell/rails3_1_strategy' if Cells.rails3_1_or_more?
     
 module Cell
   class Base < AbstractController::Base

--- a/lib/cells.rb
+++ b/lib/cells.rb
@@ -78,6 +78,10 @@ module Cells
   def self.rails3_1?
     ::Rails::VERSION::MINOR == 1
   end
+
+  def self.rails3_1_or_more?
+    ::Rails::VERSION::MINOR >= 1
+  end
 end
 
 require 'cell/rails'

--- a/test/cells_module_test.rb
+++ b/test/cells_module_test.rb
@@ -29,5 +29,18 @@ class CellsModuleTest < ActiveSupport::TestCase
         assert ! Cells.rails3_0?
       end
     end
+
+    should "respond to #rails3_1_or_more?" do
+      if Rails::VERSION::MINOR == 0
+        assert ! Cells.rails3_1_or_more?
+        assert Cells.rails3_0?
+      elsif Rails::VERSION::MINOR == 1
+        assert Cells.rails3_1_or_more?
+        assert ! Cells.rails3_0?
+      elsif Rails::VERSION::MINOR == 2
+        assert Cells.rails3_1_or_more?
+        assert ! Cells.rails3_0?
+      end
+    end
   end
 end


### PR DESCRIPTION
This allows cells to use 3.1 strategy on rails 3.2 (issue #90)
