### PR TITLE
Unit tests of namespaced cells are put in proper directory hierarchy

### DIFF
--- a/lib/generators/test_unit/cell_generator.rb
+++ b/lib/generators/test_unit/cell_generator.rb
@@ -7,7 +7,7 @@ module TestUnit
 
       def create_test
         @states = actions
-        template 'cell_test.rb', File.join('test/cells/', "#{file_name}_cell_test.rb")
+        template 'cell_test.rb', File.join('test/cells/', class_path, "#{file_name}_cell_test.rb")
       end
     end
   end

--- a/test/cell_generator_test.rb
+++ b/test/cell_generator_test.rb
@@ -95,6 +95,12 @@ class CellGeneratorTest < Rails::Generators::TestCase
       assert_file "test/cells/blog_cell_test.rb"
     end
 
+    should "work with namespace and test_unit" do
+      run_generator %w(Blog::Post latest -t test_unit)
+
+      assert_file "test/cells/blog/post_cell_test.rb",  /class Blog::PostCellTest < Cell::TestCase/
+    end
+
     should "create test_unit assets with -t rspec" do
       run_generator %w(Blog post latest -t rspec)
 


### PR DESCRIPTION
This is simple fix which puts test file of namespaced cell in proper /test/cells/ sub-directory reflecting the cell's code hierarchy. Rails' controller generator is using the same way. Test case updated.
