### PR TITLE
correct append_view_path example

### DIFF
--- a/lib/cells.rb
+++ b/lib/cells.rb
@@ -64,7 +64,7 @@ module Cells
   # Example:
   #
   #   Cells.setup do |config|
-  #     config.append_view_path << "app/view_models"
+  #     config.append_view_path "app/view_models"
   #   end
   #
   def self.setup


### PR DESCRIPTION
tested myself and `config.append_view_path "app/view_models"` will work while `config.append_view_path << "app/view_models"` won't.
