### PR TITLE
except nil in state ivars.

### DIFF
--- a/lib/cell/test_case.rb
+++ b/lib/cell/test_case.rb
@@ -78,7 +78,7 @@ module Cell
         Hash[(after - before).collect do |var|
           next if var =~ /^@_/
           [var[1, var.length].to_sym, cell.instance_variable_get(var)]
-        end]
+        end.compact]
       end
     end
     


### PR DESCRIPTION
ruby-2.0.0preview1 isn't working with Hash[[nil, ...]]. example for:

```
test: A TestCase #view_assigns should return the instance variables from the last #render_cell. (TestCaseTest):
ArgumentError: wrong element type (expected array)
```

Because ruby-2.0.0 validates wrong argument when use Hash[] now. I fixed it.
