### PR TITLE
Update 3_0 strategy to use Rails#application

### DIFF
--- a/lib/cell/rails3_0_strategy.rb
+++ b/lib/cell/rails3_0_strategy.rb
@@ -69,7 +69,7 @@ module Cells
   module Engines
     module VersionStrategy
       def registered_engines
-        ::Rails::Application.railties.engines
+        ::Rails.application.railties.engines
       end
       
       def existent_directories_for(path)


### PR DESCRIPTION
A hopefully simpler fix for #122

So when using cells on a 3_0 app I always get a warning:
`DEPRECATION WARNING: Calling a method in Rails::Application is deprecated, please call it directly in your application constant Foo::Application. (called from <top (required)> at /Users/anthony/development/foo/config/environment.rb:5)
`

I believe that it stems from calling Rails::Application in `rails3_0_strategy.rb`

I changed the call to Rails.application after which the tests still pass (https://travis-ci.org/ajlai/cells/builds/4081984) and the warning is now gone.

Let me know if there's anything more I should do. Thanks!
