### PR TITLE
Engines and relative url root

### DIFF
--- a/lib/cell/rails.rb
+++ b/lib/cell/rails.rb
@@ -6,7 +6,7 @@ module Cell
     include ActionController::RequestForgeryProtection
     
     abstract!
-    delegate :session, :params, :request, :config, :env, :url_options, :to => :parent_controller
+    delegate :session, :params, :request, :config, :env, :url_options, :_with_routes, :to => :parent_controller
     
     class << self
       def cache_store


### PR DESCRIPTION
I have a rails app with an relative url '/url_root' and an engine mounted at '/engine'. In a rails view the url are generated correctly /url_root/engine however in a cell this not the case and I only get '/url_root'. This is because the url_options of the engine (calling engine.url_options) include the script_name which overwrites the default prefix generation. This is not the case in a normal view.

The engine is represented in a view by a [routes proxy](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/routing/routes_proxy.rb#L16) and its url_options calls scope._with_routes with the routes of the engine. In a cell context the scope is the cell and therefore this method gets called on the cell however the url_options methods is just delegated to the parent controller which does at this point know nothing of the engine routes.

By delegating the _with_routes method to the parent controller this issue can be fixed. The call in the routes proxy is the only call of _with_routes I found in the rails source code so there should be no side effects.
