### PR TITLE
Suppress bundler warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source 'https://rubygems.org'
 
 gemspec
 


### PR DESCRIPTION
bundler 1.3.x shows the following warning:

```
The source :gemcutter is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or
'http://rubygems.org' if not.
```
