### PR TITLE
Multiple properties now can be provided to a single property call

### DIFF
--- a/lib/cell/rails/view_model.rb
+++ b/lib/cell/rails/view_model.rb
@@ -12,8 +12,10 @@ class Cell::Rails
     attr_reader :model
 
     module ClassMethods
-      def property(name)
-        delegate name, :to => :model
+      def property(*names)
+        names.each do |name|
+          delegate name, :to => :model
+        end
       end
     end
     extend ActiveSupport::Concern

--- a/test/rails/view_model_test.rb
+++ b/test/rails/view_model_test.rb
@@ -64,11 +64,12 @@ class ViewModelTest < MiniTest::Spec
 
   class HitCell < Cell::Base
     include Cell::Rails::ViewModel
-    property :title
+    property :title, :artist
   end
 
-  let (:song) { Song.new(:title => "65") }
+  let (:song) { Song.new(:title => "65", artist: "Boss") }
   it { HitCell.new(song).title.must_equal "65" }
+  it { HitCell.new(song).artist.must_equal "The Boss" }
  end
 
 if Cell.rails3_2_or_more?


### PR DESCRIPTION
Or was it a conscious call to have it only accept a single argument?
