### PR TITLE
Fix for 4.2

### DIFF
--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -5,7 +5,7 @@ require 'cell/version'
 
 module Cell
   def self.rails_version
-    Gem::Specification.find_by_name('actionpack').version
+    Gem::Version.new(ActionPack::VERSION::STRING)
   end
 
   class TemplateMissingError < RuntimeError


### PR DESCRIPTION
We should probably rename that method to actionpack_version
