### PR TITLE
Update rails rake task to run rails4.2 test suite

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,11 +12,16 @@ Rake::TestTask.new(:test) do |test|
   test.verbose = true
 end
 
-# Rake::TestTask.new(:rails) do |test|
-#   test.libs << 'test/rails'
-#   test.test_files = FileList['test/rails4.2/*_test.rb']
-#   test.verbose = true
-# end
+task :rails do
+  Bundler.with_clean_env do
+    Dir.chdir("test/rails4.2") do
+      sh "bundle exec rake", verbose: false do
+        # Do nothing if suite fails, allowing us to see the results for all of
+        # them, even if some of the suites have failing tests
+      end
+    end
+  end
+end
 
 # rails_task = Rake::Task["rails"]
 # test_task = Rake::Task["test"]

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ Bundler::GemHelper.install_tasks
 require 'rake/testtask'
 
 desc 'Default: run unit tests.'
-task :default => :test
+task :default => [:test, :rails]
 
 Rake::TestTask.new(:test) do |test|
   test.libs << 'test'
@@ -22,8 +22,3 @@ task :rails do
     end
   end
 end
-
-# rails_task = Rake::Task["rails"]
-# test_task = Rake::Task["test"]
-# default_task.enhance { test_task.invoke }
-# default_task.enhance { rails_task.invoke }


### PR DESCRIPTION
@apotonick This will run the rails4.2 test suite with `rake rails`. However, when run with `bundle exec rake rails` it breaks because the Gemfile at the root of the gem is loaded instead of the Gemfile in the `test/rails4.2` directory. It will work when running `BUNDLE_GEMFILE=test/rails4.2/Gemfile bundle exec rake rails`. 

Trying to find a workaround so that this is not necessary. Any ideas?
