### PR TITLE
Improve rails development reloading

### DIFF
--- a/lib/cell/development.rb
+++ b/lib/cell/development.rb
@@ -7,5 +7,19 @@ module Cell
         end
       end
     end
+
+    module Clearable
+      def self.included(base)
+        base.instance_eval do
+          def templates
+            @@templates ||= Templates.new
+          end
+
+          def clear_templates!
+            @@templates = nil
+          end
+        end
+      end
+    end
   end
 end

--- a/lib/cell/railtie.rb
+++ b/lib/cell/railtie.rb
@@ -55,8 +55,8 @@ module Cell
     end
     #   ViewModel.template_engine = app.config.app_generators.rails.fetch(:template_engine, 'erb').to_s
 
-    initializer('cells.development') do |app|
-      if Rails.env == "development"
+    initializer('cells.reloading') do |app|
+      unless app.config.cache_classes
         require "cell/development"
         ViewModel.send(:include, Development)
       end

--- a/lib/cell/railtie.rb
+++ b/lib/cell/railtie.rb
@@ -58,7 +58,29 @@ module Cell
     initializer('cells.reloading') do |app|
       unless app.config.cache_classes
         require "cell/development"
-        ViewModel.send(:include, Development)
+        ViewModel.send(:include, Development::Clearable)
+
+        callback = lambda do
+          Cell::ViewModel.clear_templates!
+        end
+
+        if app.config.reload_classes_only_on_change
+          dirs = {}
+          extentions = ["haml", "erb", "slim"]
+          view_paths = Cell::ViewModel.view_paths + Cell::Concept.view_paths
+          view_paths.each do |path|
+            dirs[path] = extentions
+          end
+
+          reloader = app.config.file_watcher.new([], dirs, &callback)
+          app.reloaders << reloader
+
+          ActionDispatch::Reloader.to_prepare(prepend: true) do
+            reloader.execute_if_updated
+          end
+        else
+          ActionDispatch::Reloader.to_cleanup(&callback)
+        end
       end
     end
 


### PR DESCRIPTION
There are two problems:
1. `ViewModel.templates` is reseted on each call in rails development env. This brakes the caching of `Templates`, which results in the fact that `Tilt` need's to compile each template on each use. For example if you have a collection cell with 10 items, Tilt compiles the template 10 times. The fact that `ViewModel.templates` is now cashed brings a speed up of 1ms per render call.
2. Solving point 1. brings a new problem, changes in development env have now no effect. That is solved by clearing the cache on each template file change.
