### PR TITLE
allow assign parameters for testing controller

### DIFF
--- a/lib/cell/testing.rb
+++ b/lib/cell/testing.rb
@@ -42,12 +42,13 @@ module Cell
 
 
     # Rails specific.
-    def controller_for(controller_class)
+    def controller_for(controller_class, action = nil, params = {})
       # TODO: test without controller.
       return unless controller_class
 
       controller_class.new.tap do |ctl|
         ctl.request = ::ActionController::TestRequest.new
+        ctl.request.assign_parameters(@routes, ctl.class.controller_path, action, params) if action
         ctl.instance_variable_set :@routes, ::Rails.application.routes.url_helpers
       end
     end


### PR DESCRIPTION
The current implementation of `Testing#controller_for` don't initialize the test request in the right way, this results in problems with the usage of some Rails Url helpers.

This idea came form https://github.com/rails/rails/blob/v4.2.0/actionpack/lib/action_controller/test_case.rb#L616
