### PR TITLE
Cache controller value in Cell::Testing

### DIFF
--- a/lib/cell/testing.rb
+++ b/lib/cell/testing.rb
@@ -53,7 +53,7 @@ module Cell
     end
 
     def controller # FIXME: this won't allow us using let(:controller) in MiniTest.
-      controller_for(self.class.controller_class)
+      @controller ||= controller_for(self.class.controller_class)
     end
 
     def self.included(base)


### PR DESCRIPTION
`controller` value should be cached so that we are able to use code like this in specs:

``` ruby
before { controller.sign_in(user) }
before { controller.stub(mobile_device?: true) }
# etc. 
```
