### PR TITLE
Use layout.build instead of layout.new

### DIFF
--- a/lib/cell/layout.rb
+++ b/lib/cell/layout.rb
@@ -48,7 +48,7 @@ module Cell
           return content unless layout = layout # TODO: test when invoking cell without :layout.
 
           # DISCUSS: should we allow instances, too? we could cache the layout cell.
-          layout.new(model, context: options[:context]).(&lambda { content })
+          layout.build(model, context: options[:context]).(&lambda { content })
         end
       end # External
     end

--- a/test/fixtures/comment/layout/show.erb
+++ b/test/fixtures/comment/layout/show.erb
@@ -1,1 +1,1 @@
-$layout.erb{<%= yield %>, <%= context.inspect %>}
+$layout.erb{<%= self.class %>, <%= yield %>, <%= context.inspect %>}

--- a/test/layout_test.rb
+++ b/test/layout_test.rb
@@ -68,24 +68,39 @@ module Comment
   end
 
   class LayoutCell < Cell::ViewModel
+    include Cell::Builder
+
+    builds { |_, context:, **| SpecialLayoutCell if context.to_h.fetch(:special_layout, false) }
+
     self.view_paths = ['test/fixtures']
+  end
+
+  class SpecialLayoutCell < LayoutCell
   end
 end
 
 class ExternalLayoutTest < Minitest::Spec
   it do
     Comment::ShowCell.new(nil, layout: Comment::LayoutCell, context: { beer: true }).
-      ().must_equal "$layout.erb{$show.erb, {:beer=>true}\n$show.erb, {:beer=>true}\n, {:beer=>true}}\n"
+      ().must_equal "$layout.erb{Comment::LayoutCell, $show.erb, {:beer=>true}\n$show.erb, {:beer=>true}\n, {:beer=>true}}\n"
   end
 
   # collection :layout
   it do
     Cell::ViewModel.cell("comment/show", collection: [Object, Module], layout: Comment::LayoutCell).().
-      must_equal "$layout.erb{$show.erb, nil
+      must_equal "$layout.erb{Comment::LayoutCell, $show.erb, nil
 $show.erb, nil
 $show.erb, nil
 $show.erb, nil
 , nil}
+"
+  end
+
+  it 'renders special layout if requested' do
+    Comment::ShowCell.new(nil, layout: Comment::LayoutCell, context: { special_layout: true }).
+      ().must_equal "$layout.erb{Comment::SpecialLayoutCell, $show.erb, {:special_layout=>true}
+$show.erb, {:special_layout=>true}
+, {:special_layout=>true}}
 "
   end
 end


### PR DESCRIPTION
Use layout.build instead of layout.new in Cell::ViewModel::Layout::External.

Reason: allow layout class to be selected using context.
I.e. builds { |_, context:, **| self::Mobile if context[:mobile] }
