### PR TITLE
Add deprecation warning for Cell::Concept

### DIFF
--- a/lib/cell/concept.rb
+++ b/lib/cell/concept.rb
@@ -7,6 +7,11 @@ module Cell
     self.view_paths = ["app/concepts"]
     extend SelfContained
 
+    def initialize(*args)
+      puts 'WARNING: Cell::Concept is no longer under active development. Please switch to Cell::ViewModel or Trailblazer::Cell.'
+      super
+    end
+
     # TODO: this should be in Helper or something. this should be the only entry point from controller/view.
     class << self
       def class_from_cell_name(name)


### PR DESCRIPTION
The TRB book makes heavy use of `Cell::Concept`, and I wasn't sure what the difference is between this and `Cell::ViewModel` or `Trailblazer::Cell`... and on having a look in the source, I spotted [this](https://github.com/apotonick/cells/blob/master/lib/cell/concept.rb#L4) easy-to-miss comment.

> Cell::Concept is no longer under active development. Please switch to Trailblazer::Cell.

This PR makes this warning more obvious by moving it from a comment to a `puts` statement when you initialize a new `Cell::Concept`. I realise that putting this in the `initialize` method isn't ideal, but Ruby's own `deprecate` method requires you to specify a specific *method* that's deprecated rather than deprecating the class as a whole. (None of the answers to [this SO question](https://stackoverflow.com/questions/29695995/how-to-mark-a-class-as-deprecated-in-ruby) really strike me as great solutions to the 'how do I deprecate an entire class?' question.)

Apologies if this class isn't actually "deprecated" in the sense that you're planning on removing it (as opposed to leaving it in there but not continuing active development on it.)