### PR TITLE
Allow Collection#join to be used without a block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+* `Collection#join` can now be called without a block.
+
 ## 4.1.6
 
 * Use `Declarative::Option` and `Declarative::Builder` instead of `uber`'s. This allows removing the `uber` version restriction.

--- a/lib/cell/collection.rb
+++ b/lib/cell/collection.rb
@@ -31,9 +31,9 @@ module Cell
     # Its return value is captured and joined.
     def join(separator="", &block)
       @ary.each_with_index.collect do |model, i|
-        yield @cell_class.build(model, @options), i
-      end.
-        join(separator)
+        cell = @cell_class.build(model, @options)
+        block_given? ? yield(cell, i) : cell
+      end.join(separator)
     end
 
     module Layout

--- a/test/public_test.rb
+++ b/test/public_test.rb
@@ -89,4 +89,11 @@ class PublicTest < MiniTest::Spec
       i == 1 ? cell.(:detail) : cell.()
     end.must_equal '[Object, {}]>* [Module, {}]'
   end
+
+  # 'join' can be used without a block:
+  it do
+    Cell::ViewModel.cell(
+      "public_test/song", collection: [Object, Module]
+    ).join('---').must_equal('[Object, {}]---[Module, {}]')
+  end
 end


### PR DESCRIPTION
Most of the time when I use `Collection#join`, I don't actually care about calling custom methods etc., I just want to stick some HTML in between each rendered cell. But `#join` insists on taking a block, so I have to do something like this:

    my_collection.join('<hr>') { |cell| cell }

This PR makes the block optional, so I can just do it like this:

    my_collection.join('<hr>')