### PR TITLE
add ViewModel.option

### DIFF
--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+
+class OptionsTest < MiniTest::Spec
+  Song = Struct.new(:title)
+  Hit  = Struct.new(:title)
+
+  class CellWithOptions < Cell::ViewModel
+    option :non_required
+    option :required, required: true
+    option :has_default, default: 'hola'
+
+    def show
+      [non_required, required, has_default].join('-')
+    end
+
+    def show_non_required
+      non_required
+    end
+
+    def show_required
+      required
+    end
+
+    def show_has_default
+      has_default
+    end
+  end
+
+  # basic usage
+  it do
+    cell = CellWithOptions.(nil, non_required: 'a', required: 'b', has_default: 'c')
+    cell.show_non_required.must_equal 'a'
+    cell.show_required.must_equal 'b'
+    cell.show_has_default.must_equal 'c'
+  end
+
+  # missing required option
+  it do
+    assert_raises Cell::MissingOptionError do
+      CellWithOptions.(nil, non_required: 'a', has_default: 'b')
+    end
+  end
+
+  # non-required options with and without default
+  it do
+    cell = CellWithOptions.(nil, required: 'a')
+    assert_nil cell.show_non_required
+    cell.show_has_default.must_equal 'hola'
+  end
+
+  # collection
+  it do
+    # with missing required option:
+    assert_raises Cell::MissingOptionError do
+      CellWithOptions.(collection: [1, 2]).()
+    end
+
+    cells = CellWithOptions.(collection: [1, 2], non_required: 'a', required: 'b', has_default: 'c')
+    cells.join(' ').to_s.must_equal('a-b-c a-b-c')
+  end
+end


### PR DESCRIPTION
I've always found it strange that there's a `property` method which lets me easily create accessors for properties of the cell's `model`, but there's no similar mechanism for easily creating accessors for keys on the `options` hash. It feels like a big omission to me - is there a deliberate reason it hasn't been added?

This PR is based on a monkey-patch that I've been using in my own project for a couple of months now. It allows you to do something like this:

```ruby
class Foo < Cell::ViewModel # or Trailblazer::Cell
  option :hello
end

# usage

cell(Foo, my_model, hello: 'guten tag')

# in the view:

<%= hello %>
```

Whereas previously you'd have to do it like this:

```ruby
class Foo < Cell::ViewModel # or Trailblazer::Cell
  private

  def hello
    options[:hello] # or options.fetch(:hello) if you want to make it compulsory
  end  
end
```

One weakness of this feature as it stands is that accessors defined with `option` aren't escaped when `Escaped` is included, which might violate the POLA. But this is a starting point.