### PR TITLE
Remove deprecated `must_equal(nil)` syntax from tests

### DIFF
--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -34,9 +34,9 @@ class ContextTest < MiniTest::Spec
   it do
     child = parent.cell(ParentCell, nil, context: { "is_child?" => true })
 
-    parent.context["is_child?"].must_equal nil
+    assert_nil(parent.context["is_child?"])
 
-    child.model.must_equal nil
+    assert_nil(child.model)
     child.controller.must_equal controller
     child.user.must_equal user
     child.context["is_child?"].must_equal true

--- a/test/templates_test.rb
+++ b/test/templates_test.rb
@@ -8,7 +8,7 @@ class TemplatesTest < MiniTest::Spec
   it { Templates.new[['test/fixtures/bassist'], 'play.erb', {template_class: Cell::Erb::Template}].file.must_equal 'test/fixtures/bassist/play.erb' }
 
   # not existing.
-  it { Templates.new[['test/fixtures/bassist'], 'not-here.erb', {}].must_equal nil }
+  it { assert_nil(Templates.new[['test/fixtures/bassist'], 'not-here.erb', {}]) }
 
 
   # different caches for different classes


### PR DESCRIPTION
When I run the tests on `master` with Minitest I get the following warning in a couple of places:

    Use assert_nil if expecting nil from /Users/george/.rvm/gems/ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.

This PR updates the tests to remove the warnings.