### PR TITLE
bump cells-erb dev dependency to >= 0.1.0

### DIFF
--- a/cells.gemspec
+++ b/cells.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "capybara"
-  spec.add_development_dependency "cells-erb", ">= 0.0.4"
+  spec.add_development_dependency "cells-erb", ">= 0.1.0"
 end


### PR DESCRIPTION
If you clone from master and `bundle install` and cells-erb gets resolved to <
0.1.0, then a bunch of tests will fail (because the tested cells will render
strings with newlines on the end, but the tests don't expect the newline.)
Upgrading cells-erb to 0.1.0 fixes this. This PR makes the dependency explicit.

See also #451