### PR TITLE
README: Build badge point to trailblazer/cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Gitter Chat](https://badges.gitter.im/trailblazer/chat.svg)](https://gitter.im/trailblazer/chat)
 [![TRB Newsletter](https://img.shields.io/badge/TRB-newsletter-lightgrey.svg)](http://trailblazer.to/newsletter/)
 [![Build
-Status](https://travis-ci.org/apotonick/cells.svg)](https://travis-ci.org/apotonick/cells)
+Status](https://travis-ci.org/trailblazer/cells.svg)](https://travis-ci.org/trailblazer/cells)
 [![Gem Version](https://badge.fury.io/rb/cells.svg)](http://badge.fury.io/rb/cells)
 
 ## Overview


### PR DESCRIPTION
This PR changes the build badges to point to `trailblazer`'s version, not `apotonick`'s.