### PR TITLE
Allow setting a custom suffix in render options

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Gitter Chat](https://badges.gitter.im/trailblazer/chat.svg)](https://gitter.im/trailblazer/chat)
 [![TRB Newsletter](https://img.shields.io/badge/TRB-newsletter-lightgrey.svg)](http://trailblazer.to/newsletter/)
 [![Build
-Status](https://travis-ci.org/apotonick/cells.svg)](https://travis-ci.org/apotonick/cells)
+Status](https://travis-ci.org/trailblazer/cells.svg)](https://travis-ci.org/trailblazer/cells)
 [![Gem Version](https://badge.fury.io/rb/cells.svg)](http://badge.fury.io/rb/cells)
 
 ## Overview

--- a/cells.gemspec
+++ b/cells.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "capybara"
-  spec.add_development_dependency "cells-erb", ">= 0.0.4"
+  spec.add_development_dependency "cells-erb", ">= 0.1.0"
 end

--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -161,7 +161,7 @@ module Cell
 
         view      = options[:view]
         prefixes  = options[:prefixes]
-        suffix    = template_options.delete(:suffix)
+        suffix    = options[:suffix] || template_options.delete(:suffix)
         view      = "#{view}.#{suffix}"
 
         template_for(prefixes, view, template_options) or raise TemplateMissingError.new(prefixes, view)


### PR DESCRIPTION
Using this you can find a file name with a custom extension

```ruby
#cells/my_mailer_cell.rb
class MyMailerCell < Cell::ViewModel
  include Partial
end
```

```erb
<!-- cells/my_mailer/some_view.erb -->
...
render partial: '../views/mailer/shared/inky-partial, suffix: :'inky-erb, formats: [:html],'
...
```

```html
<!-- views/mailer/shared/_inky-partial.html.inky-erb -->
<row>
  <columns></columns>
  <columns>Easy emails with Inky templating language</columns>
  <columns></columns>
</row>
```

cf https://github.com/trailblazer/cells-erb/issues/8