### PR TITLE
Properly check for key presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Gitter Chat](https://badges.gitter.im/trailblazer/chat.svg)](https://gitter.im/trailblazer/chat)
 [![TRB Newsletter](https://img.shields.io/badge/TRB-newsletter-lightgrey.svg)](http://trailblazer.to/newsletter/)
 [![Build
-Status](https://travis-ci.org/apotonick/cells.svg)](https://travis-ci.org/apotonick/cells)
+Status](https://travis-ci.org/trailblazer/cells.svg)](https://travis-ci.org/trailblazer/cells)
 [![Gem Version](https://badge.fury.io/rb/cells.svg)](http://badge.fury.io/rb/cells)
 
 ## Overview

--- a/cells.gemspec
+++ b/cells.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "capybara"
-  spec.add_development_dependency "cells-erb", ">= 0.0.4"
+  spec.add_development_dependency "cells-erb", ">= 0.1.0"
 end

--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -45,8 +45,8 @@ module Cell
       #   SongCell.(@song)
       #   SongCell.(collection: Song.all)
       def call(model=nil, options={}, &block)
-        if model.is_a?(Hash) and array = model[:collection]
-          return Collection.new(array, model.merge(options), self)
+        if model.is_a?(Hash) and model.key?(:collection)
+          return Collection.new(model[:collection], model.merge(options), self)
         end
 
         build(model, options)


### PR DESCRIPTION
Hashes can have default values different from `nil`, see https://docs.ruby-lang.org/en/2.5.0/Hash.html#method-i-default-3D

So we must not rely on the hash returning `nil` for missing keys.