### PR TITLE
Update tested Ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
   #- ruby-head
-  - 2.3.1
-  - 2.2.2
+  - 2.5
+  - 2.4.3
+  - 2.3.6
 
 sudo: false
 cache: bundler


### PR DESCRIPTION
Ruby 2.2 is reaching it's end of life at the end of the month. But I think it's useful to test recent Ruby versions as well.