### PR TITLE
Fix the readme markup on Cells 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ Note how the block is run in the global view's context, allowing you to use glob
 
 You need to include the `disposable` gem in order to use this.
 
-````ruby
+```ruby
 gem "disposable"
 ```
 


### PR DESCRIPTION
The extra grave accent messes the formatting of the documentation in Cells 3, which I'm forced to use for now.

https://github.com/trailblazer/cells/blob/v3.11.3/README.md#using-decorators-twins