### PR TITLE
Tilt cache

### DIFF
--- a/lib/cell/templates.rb
+++ b/lib/cell/templates.rb
@@ -7,15 +7,17 @@ module Cell
     end
 
   private
-
     def cache
-      @cache ||= Cache.new
+      @cache ||= Tilt::Cache.new
     end
 
     def find_template(prefixes, view, options) # options is not considered in cache key.
-      cache.fetch(prefixes, view) do |prefix|
-        # this block is run once per cell class per process, for each prefix/view tuple.
-        create(prefix, view, options)
+      cache.fetch(prefixes, view) do
+        template = nil
+        prefixes.find do |prefix|
+          template = create(prefix, view, options)
+        end
+        template
       end
     end
 
@@ -25,34 +27,6 @@ module Cell
 
       template_class = options.delete(:template_class)
       template_class.new("#{prefix}/#{view}", options) # Tilt.new()
-    end
-
-    # {["comment/row/views", comment/views"]["show.haml"] => "Tpl:comment/view/show.haml"}
-    class Cache
-      def initialize
-        @store = {}
-      end
-
-      # Iterates prefixes and yields block. Returns and caches when block returned template.
-      # Note that it caches per prefixes set as this will most probably never change.
-      def fetch(prefixes, view)
-        template = get(prefixes, view) and return template # cache hit.
-
-        prefixes.find do |prefix|
-          template = yield(prefix) and return store(prefixes, view, template)
-        end
-      end
-
-    private
-      # ["comment/views"] => "show.haml"
-      def get(prefixes, view)
-        @store[prefixes] ||= {}
-        @store[prefixes][view]
-      end
-
-      def store(prefix, view, template)
-        @store[prefix][view] = template # the nested hash is always present here.
-      end
     end
   end
 end

--- a/lib/cell/templates.rb
+++ b/lib/cell/templates.rb
@@ -13,20 +13,11 @@ module Cell
 
     def find_template(prefixes, view, options) # options is not considered in cache key.
       cache.fetch(prefixes, view) do
-        template = nil
-        prefixes.find do |prefix|
-          template = create(prefix, view, options)
-        end
-        template
+        template_prefix = prefixes.find { |prefix| File.exist?("#{prefix}/#{view}") }
+        return if template_prefix.nil? # We can safely return early. Tilt::Cache does not cache nils.
+        template_class = options.delete(:template_class)
+        template_class.new("#{template_prefix}/#{view}", options) # Tilt.new()
       end
-    end
-
-    def create(prefix, view, options)
-      # puts "...checking #{prefix}/#{view}"
-      return unless File.exist?("#{prefix}/#{view}") # DISCUSS: can we use Tilt.new here?
-
-      template_class = options.delete(:template_class)
-      template_class.new("#{prefix}/#{view}", options) # Tilt.new()
     end
   end
 end


### PR DESCRIPTION
Use Tilt::Cache instead of our own cache implementation

Tilt::Cache does exactly the same. Using that one cleans up our code significantly.