### PR TITLE
Update `expand_cache_key` to utilise `cache_key` method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+* Call `cache_key` on objects used in cache keys instead of `to_s` when possible.
+
 ## 4.1.8
 
 * Fix ruby warning with undefined instance variable in codebase

--- a/lib/cell/caching.rb
+++ b/lib/cell/caching.rb
@@ -36,8 +36,11 @@ module Cell
 
     private
 
-      def expand_cache_key(key)
-        key.join("/")
+      def expand_cache_key(full_key)
+        computed_keys = full_key.flatten.map do |key|
+          key.respond_to?(:cache_key) ? key.cache_key : key.to_s
+        end
+        computed_keys.join('/')
       end
     end
 

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -19,14 +19,57 @@ class CacheTest < Minitest::Spec
     end
   end
 
+  class CacheableModel
+    attr_accessor :id, :value, :timestamp
+
+    def initialize(id, value, timestamp)
+      @id = id
+      @value = value
+      @timestamp = timestamp
+    end
+
+    def cache_key
+      [@id, @timestamp]
+    end
+
+    def to_s
+      @value
+    end
+  end
+
   class Index < Cell::ViewModel
     cache :show
     include Cache
   end
 
+  class CacheKeyedIndex < Cell::ViewModel
+    cache :show do
+      @model
+    end
+    include Cache
+  end
+
   it do
-    Index.new(1).().must_equal("1")
-    Index.new(2).().must_equal("1")
+    Index.new(1).().must_equal('1')
+    Index.new(2).().must_equal('1')
+  end
+
+  it do
+    # Both models cache differently due to unique ID/time combinations
+    model_a = CacheableModel.new('id-1', 'abc', Time.now)
+    model_b = CacheableModel.new('id-2', 'efg', Time.now)
+
+    CacheKeyedIndex.new(model_a).().must_equal('abc')
+    CacheKeyedIndex.new(model_b).().must_equal('efg')
+
+    # Model A returns from cache as ID/time haven't updated
+    model_a.value = 'xyz'
+
+    CacheKeyedIndex.new(model_a).().must_equal('abc')
+
+    # Model A should cache new value as the timestamp is now different
+    model_a.timestamp = Time.local(2000, 1, 1)
+
+    CacheKeyedIndex.new(model_a).().must_equal('xyz')
   end
 end
-


### PR DESCRIPTION
When passing a cache key through to the `cache` method of a cell view, the underlying cache key is constructed using a simple `join('/')` which will call `to_s` on all objects as part of that key.

I've updated the `expand_cache_key` method in the caching module so that it will try to utilise a `cache_key` method on any objects in the cache key if available, otherwise it will fallback to using `to_s` which is inline with the current behaviour.

The benefits of this are that you can allow models/objects to define their own cache key without explicitly requiring the cell class to be aware of it. 

As the Rails models automatically get their own free `cache_key` method which is a composite of the model's ID and last updated time and is used in Rails' own view caching. This would mean that users of Rails and `cells`/`cells-rails` will also get consistent behaviour when using the cache key mechanisms provided by both Rails and Cells.