### PR TITLE
Use trailblazer-option over declarative-option and upgrade declarative-builder

### DIFF
--- a/cells.gemspec
+++ b/cells.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.2.10"
 
-  spec.add_dependency "declarative-builder", "< 0.2.0"
-  spec.add_dependency "declarative-option", "< 0.2.0"
+  spec.add_dependency "declarative-builder", "~> 0.2.0"
+  spec.add_dependency "trailblazer-option", "~> 0.1.0"
   spec.add_dependency "tilt", ">= 1.4", "< 3"
   spec.add_dependency "uber", "< 0.2.0"
 

--- a/lib/cell/caching.rb
+++ b/lib/cell/caching.rb
@@ -1,4 +1,4 @@
-require "declarative/options"
+require "cell/option"
 
 module Cell
   module Caching
@@ -17,12 +17,10 @@ module Cell
     end
 
     module ClassMethods
-      def cache(state, *args, &block)
-        options = args.last.is_a?(Hash) ? args.pop : {} # I have to admit, Array#extract_options is a brilliant tool.
-
-        conditional_procs[state] = Declarative::Option(options.delete(:if) || true, instance_exec: true)
-        version_procs[state]     = Declarative::Option(args.first || block, instance_exec: true)
-        cache_options[state]     = Declarative::Options(options, instance_exec: true)
+      def cache(state, *args, **kwargs, &block)
+        conditional_procs[state] = Cell::Option(kwargs.delete(:if) || true)
+        version_procs[state]     = Cell::Option(args.first || block)
+        cache_options[state]     = Cell::Options(kwargs)
       end
 
       # Computes the complete, namespaced cache key for +state+.
@@ -45,8 +43,8 @@ module Cell
       state = state.to_sym
       return super(state, *args) unless cache?(state, *args)
 
-      key     = self.class.state_cache_key(state, self.class.version_procs[state].(self, *args))
-      options = self.class.cache_options[state].(self, *args)
+      key     = self.class.state_cache_key(state, self.class.version_procs[state].(*args, exec_context: self))
+      options = self.class.cache_options[state].(*args, exec_context: self)
 
       fetch_from_cache_for(key, options) { super(state, *args) }
     end
@@ -56,7 +54,7 @@ module Cell
     end
 
     def cache?(state, *args)
-      perform_caching? and state_cached?(state) and self.class.conditional_procs[state].(self, *args)
+      perform_caching? and state_cached?(state) and self.class.conditional_procs[state].(*args, exec_context: self)
     end
 
   private

--- a/lib/cell/option.rb
+++ b/lib/cell/option.rb
@@ -1,18 +1,18 @@
 require "trailblazer/option"
 require "uber/callable"
 
-# DISCUSS: Should we move this to trb-option instead ?
-# This is identical to `Representable::Option`.
 module Cell
-  # Extend `Trailblazer::Option` to support static values as callables too.
+  # Extend `Trailblazer::Option` to make static values as callables too.
   class Option < ::Trailblazer::Option
-    def self.callable?(value)
-      [Proc, Symbol, Uber::Callable].any?{ |kind| value.is_a?(kind) }
-    end
-
     def self.build(value)
-      return ->(*) { value } unless callable?(value) # Wrap static `value` into a proc. 
-      super
+      callable = case value
+                 when Proc, Symbol, Uber::Callable
+                   value
+                 else
+                   ->(*) { value } # Make non-callable value to callable.
+                 end
+
+      super(callable)
     end
   end
 

--- a/lib/cell/option.rb
+++ b/lib/cell/option.rb
@@ -1,0 +1,35 @@
+require "trailblazer/option"
+require "uber/callable"
+
+# DISCUSS: Should we move this to trb-option instead ?
+# This is identical to `Representable::Option`.
+module Cell
+  # Extend `Trailblazer::Option` to support static values as callables too.
+  class Option < ::Trailblazer::Option
+    def self.callable?(value)
+      [Proc, Symbol, Uber::Callable].any?{ |kind| value.is_a?(kind) }
+    end
+
+    def self.build(value)
+      return ->(*) { value } unless callable?(value) # Wrap static `value` into a proc. 
+      super
+    end
+  end
+
+  class Options < Hash
+    # Evaluates every element and returns a hash.  Accepts arbitrary arguments.
+    def call(*args, **options, &block)
+      Hash[ collect { |k,v| [k,v.(*args, **options, &block) ] } ]
+    end
+  end
+
+  def self.Option(value)
+    ::Cell::Option.build(value)
+  end
+
+  def self.Options(options)
+    Options.new.tap do |hsh|
+      options.each { |k,v| hsh[k] = Option(v) }
+    end
+  end
+end

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -1,7 +1,5 @@
 require "test_helper"
 
-# TODO: test caching without rails
-
 class CacheTest < Minitest::Spec
   STORE = Class.new(Hash) do
     def fetch(key, options, &block)
@@ -10,23 +8,79 @@ class CacheTest < Minitest::Spec
   end.new
 
   module Cache
-    def show
+    def show(*)
       "#{@model}"
     end
 
     def cache_store
       STORE
     end
+
+    def has_changed?(*)
+      @model < 3
+    end
   end
 
-  class Index < Cell::ViewModel
-    cache :show
-    include Cache
+  Template = ->(action, *args, **kwargs, &block) {
+    Class.new(Cell::ViewModel) do
+      cache action, *args, **kwargs, &block
+      include Cache
+    end
+  }
+
+  it "without any arguments" do
+    Default = Template.(:show)
+
+    _(Default.new(1).()).must_equal("1")
+    _(Default.new(2).()).must_equal("1")
   end
 
-  it do
-    _(Index.new(1).()).must_equal("1")
-    _(Index.new(2).()).must_equal("1")
+  it "with specified version" do
+    # Cache invalidation using version proc
+    WithVersionArg = Template.(:show, ->(options) { options[:version] })
+
+    _(WithVersionArg.new(1).(:show, version: 1)).must_equal("1")
+    _(WithVersionArg.new(2).(:show, version: 1)).must_equal("1")
+
+    _(WithVersionArg.new(3).(:show, version: 2)).must_equal("3")
+
+    # Cache invalidation using version block
+    WithVersionBlock = Template.(:show) { |options| options[:version] }
+
+    _(WithVersionBlock.new(1).(:show, version: 1)).must_equal("1")
+    _(WithVersionBlock.new(2).(:show, version: 1)).must_equal("1")
+
+    _(WithVersionBlock.new(3).(:show, version: 2)).must_equal("3")
+  end
+
+  it "with conditional" do
+    WithConditional = Template.(:show, if: :has_changed?)
+
+    _(WithConditional.new(1).(:show)).must_equal("1")
+    _(WithConditional.new(2).(:show)).must_equal("1")
+
+    _(WithConditional.new(3).(:show)).must_equal("3")
+  end
+
+  it "forwards remaining options to cache store" do
+    WithOptions = Class.new(Cell::ViewModel) do
+      cache :show, if: :has_changed?, expires_in: 10, tags: ->(*args) { Hash(args.first)[:tags] }
+      include Cache
+
+      NEW_STORE = Class.new(Hash) do
+        def fetch(key, options)
+          value = self[key] || self[key] = yield
+          [value, options]
+        end
+      end.new
+
+      def cache_store
+        NEW_STORE
+      end
+    end
+
+    _(WithOptions.new(1).(:show)).must_equal(%{["1", {:expires_in=>10, :tags=>nil}]})
+    _(WithOptions.new(2).(:show)).must_equal(%{["1", {:expires_in=>10, :tags=>nil}]})
+    _(WithOptions.new(2).(:show, tags: [:a, :b])).must_equal(%{["1", {:expires_in=>10, :tags=>[:a, :b]}]})
   end
 end
-

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -21,31 +21,33 @@ class CacheTest < Minitest::Spec
     end
   end
 
-  Template = ->(action, *args, **kwargs, &block) {
+  Component = ->(*args, **kwargs, &block) {
     Class.new(Cell::ViewModel) do
-      cache action, *args, **kwargs, &block
+      cache :show, *args, **kwargs, &block
       include Cache
     end
   }
 
-  it "without any arguments" do
-    Default = Template.(:show)
+  it "without any options" do
+    WithoutOptions = Component.()
 
-    _(Default.new(1).()).must_equal("1")
-    _(Default.new(2).()).must_equal("1")
+    _(WithoutOptions.new(1).()).must_equal("1")
+    _(WithoutOptions.new(2).()).must_equal("1")
   end
 
   it "with specified version" do
-    # Cache invalidation using version proc
-    WithVersionArg = Template.(:show, ->(options) { options[:version] })
+    version = ->(options) { options[:version] }
+
+    # Cache invalidation using version as a proc
+    WithVersionArg = Component.(version)
 
     _(WithVersionArg.new(1).(:show, version: 1)).must_equal("1")
     _(WithVersionArg.new(2).(:show, version: 1)).must_equal("1")
 
     _(WithVersionArg.new(3).(:show, version: 2)).must_equal("3")
 
-    # Cache invalidation using version block
-    WithVersionBlock = Template.(:show) { |options| options[:version] }
+    # Cache invalidation using version as a block
+    WithVersionBlock = Component.(&version)
 
     _(WithVersionBlock.new(1).(:show, version: 1)).must_equal("1")
     _(WithVersionBlock.new(2).(:show, version: 1)).must_equal("1")
@@ -54,12 +56,12 @@ class CacheTest < Minitest::Spec
   end
 
   it "with conditional" do
-    WithConditional = Template.(:show, if: :has_changed?)
+    WithConditional = Component.(if: :has_changed?)
 
-    _(WithConditional.new(1).(:show)).must_equal("1")
-    _(WithConditional.new(2).(:show)).must_equal("1")
+    _(WithConditional.new(1).()).must_equal("1")
+    _(WithConditional.new(2).()).must_equal("1")
 
-    _(WithConditional.new(3).(:show)).must_equal("3")
+    _(WithConditional.new(3).()).must_equal("3")
   end
 
   it "forwards remaining options to cache store" do
@@ -67,7 +69,7 @@ class CacheTest < Minitest::Spec
       cache :show, if: :has_changed?, expires_in: 10, tags: ->(*args) { Hash(args.first)[:tags] }
       include Cache
 
-      NEW_STORE = Class.new(Hash) do
+      CACHE_WITH_OPTIONS_STORE = Class.new(Hash) do
         def fetch(key, options)
           value = self[key] || self[key] = yield
           [value, options]
@@ -75,12 +77,12 @@ class CacheTest < Minitest::Spec
       end.new
 
       def cache_store
-        NEW_STORE
+        CACHE_WITH_OPTIONS_STORE
       end
     end
 
-    _(WithOptions.new(1).(:show)).must_equal(%{["1", {:expires_in=>10, :tags=>nil}]})
-    _(WithOptions.new(2).(:show)).must_equal(%{["1", {:expires_in=>10, :tags=>nil}]})
+    _(WithOptions.new(1).()).must_equal(%{["1", {:expires_in=>10, :tags=>nil}]})
+    _(WithOptions.new(2).()).must_equal(%{["1", {:expires_in=>10, :tags=>nil}]})
     _(WithOptions.new(2).(:show, tags: [:a, :b])).must_equal(%{["1", {:expires_in=>10, :tags=>[:a, :b]}]})
   end
 end


### PR DESCRIPTION
- Upgrade `declarative-builder` version (referring to the reported [issue](https://trailblazer.zulipchat.com/#narrow/stream/223924-general/topic/trailblazer-cells/near/240577894))
- Replace `declarative-option` with `trailblazer-option` as `declarative-builder` uses same.