### PR TITLE
Update declarative-builder to the latest version (0.2.0)

### DIFF
--- a/cells.gemspec
+++ b/cells.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.2.10"
 
-  spec.add_dependency "declarative-builder", "< 0.2.0"
+  spec.add_dependency "declarative-builder", "~> 0.2.0"
   spec.add_dependency "declarative-option", "< 0.2.0"
   spec.add_dependency "tilt", ">= 1.4", "< 3"
   spec.add_dependency "uber", "< 0.2.0"


### PR DESCRIPTION
This is required so that this gem can be used with the latest 3.1 version of representable.

Note, I've literally only allowed the later version of declarative-builder to be used. In 0.2.0 of declarative-builder it moved from declarative-option to trailblazer-option and I haven't made the same changes here. Is that required?