### PR TITLE
Forward args in ruby3 style after cache hit

### DIFF
--- a/lib/cell/caching.rb
+++ b/lib/cell/caching.rb
@@ -51,7 +51,7 @@ module Cell
       key     = self.class.state_cache_key(state, self.class.version_procs[state].(*cache_filter_args, exec_context: self))
       options = self.class.cache_options[state].(*cache_filter_args, exec_context: self)
 
-      fetch_from_cache_for(key, options) { super(state, *cache_filter_args) }
+      fetch_from_cache_for(key, options) { super(state, *args, **kws) }
     end
 
     def cache_store  # we want to use DI to set a cache store in cell/rails.

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -90,4 +90,24 @@ class CacheTest < Minitest::Spec
     # FIXME: allow this in Cells 5.
     # _(WithOptions.new(2).(:new, my_tags: [:a, :b])).must_equal(%{["1", {:expires_in=>10, :tags=>[:a, :b]}]})
   end
+
+  it "forwards all arguments to renderer after cache hit" do
+    SongCell = Class.new(Cell::ViewModel) do
+      cache :show
+
+      def show(type, title:, part:, **)
+        "#{type} #{title} #{part}"
+      end
+
+      def cache_store
+        STORE
+      end
+    end
+
+    # cache miss for the first render
+    _(SongCell.new.(:show, "Album", title: "IT", part: "1")).must_equal("Album IT 1")
+
+    # cache hit for the second render
+    _(SongCell.new.(:show, "Album", title: "IT", part: "1")).must_equal("Album IT 1")
+  end
 end


### PR DESCRIPTION
**Issue**

kwargs were not correctly getting forwarded to renderer in case of cache hit and it raised an exception in ruby3

**Fix**

Forward kwargs in ruby3 style!